### PR TITLE
Bugfix: Added manual simulation sime step to enable busy waits in ROS executor spin

### DIFF
--- a/lib/APPTurtle/src/CustomRosTransport.cpp
+++ b/lib/APPTurtle/src/CustomRosTransport.cpp
@@ -38,6 +38,7 @@
 #include <WiFiUdp.h>
 #include <SimpleTimer.hpp>
 #include <Logging.h>
+#include <Board.h>
 
 /******************************************************************************
  * Compiler Switches
@@ -189,6 +190,11 @@ size_t custom_transport_read(uxrCustomTransport* transport, uint8_t* buffer, siz
             {
                 break;
             }
+
+/* ROS executor requires active time. Added manual simulation time step for now. */
+#if defined(TARGET_NATIVE)
+            Board::getInstance().stepTime();
+#endif
         }
 
         if (0 == udpClient.available())

--- a/lib/APPTurtle/src/CustomRosTransport.cpp
+++ b/lib/APPTurtle/src/CustomRosTransport.cpp
@@ -191,8 +191,12 @@ size_t custom_transport_read(uxrCustomTransport* transport, uint8_t* buffer, siz
                 break;
             }
 
-/* ROS executor requires active time. Added manual simulation time step for now. */
 #if defined(TARGET_NATIVE)
+            /*
+             * SimpleTimer requires simulation time to progress
+             * otherwise this loop will block until a packet was received.
+             * TODO This is a workaround which needs to be discussed further.
+             */
             Board::getInstance().stepTime();
 #endif
         }

--- a/lib/HALSim/src/Board.h
+++ b/lib/HALSim/src/Board.h
@@ -168,6 +168,15 @@ public:
     }
 
     /**
+     * Trigger simulation time step (wrapper for SimTime::step)
+     * @return True if step was successful, false otherwise.
+     */
+    bool stepTime()
+    {
+        return m_simTime.step();
+    }
+
+    /**
      * Get the file path of the configuration (settings).
      *
      * @return Configuration file path


### PR DESCRIPTION
The ROS session recv_message requires busy waits for timeouts. The simulation only progresses in time after a completed application loop. Until further changes the simulation time will be progressed while waiting for the SimpleTimer timeout loop in custom_transport_read.