### PR TITLE
MovAvg Sum Type

### DIFF
--- a/lib/ConvoyFollower/src/DrivingState.h
+++ b/lib/ConvoyFollower/src/DrivingState.h
@@ -285,7 +285,7 @@ private:
     int32_t m_cumulativeQueueDistance;
 
     /** Average distance to the predecessor in mm. */
-    MovAvg<int32_t, IVS_MOVAVG_NUMBER_OF_MEASUREMENTS> m_avgIvs;
+    MovAvg<int32_t, int32_t, IVS_MOVAVG_NUMBER_OF_MEASUREMENTS> m_avgIvs;
 
     /**
      * Get latest waypoint from the queue, validate it and set it to as the current target.

--- a/lib/HALTarget/src/Battery.h
+++ b/lib/HALTarget/src/Battery.h
@@ -93,7 +93,7 @@ private:
     static const uint32_t REFERENCE_VOLTAGE = 3300U;  /**< Reference voltage of the ADCs in millivolts*/
     static const uint32_t CONVERSION_FACTOR = 10000U; /**< Conversion factor from measured to real battery voltage. */
 
-    MovAvg<uint32_t, 2> m_voltMovAvg; /**< The moving average of the measured voltage over 2 calling cycles. */
+    MovAvg<uint32_t, uint32_t, 2U> m_voltMovAvg; /**< The moving average of the measured voltage over 2 calling cycles. */
 };
 
 /******************************************************************************

--- a/lib/Utilities/src/MovAvg.hpp
+++ b/lib/Utilities/src/MovAvg.hpp
@@ -58,9 +58,10 @@
  * It is designed for fix point integers.
  *
  * @tparam T    The data type of the moving average result and input values.
+ * @tparam U    The data type of the moving average sum. Must be able to store the maximum value of T * length.
  * @tparam length The number of values, which are considered in the moving average calculation.
  */
-template<typename T, uint8_t length>
+template<typename T, typename U, uint8_t length>
 class MovAvg
 {
 public:
@@ -149,7 +150,7 @@ private:
     T       m_values[length]; /**< List of values, used for moving average calculation. */
     uint8_t m_wrIdx;          /**< Write index to list of values */
     uint8_t m_written;        /**< The number of written values to the list of values, till length is reached. */
-    T       m_sum;            /**< Sum of all values */
+    U       m_sum;            /**< Sum of all values */
 
     /**
      * Copy construction of an instance.


### PR DESCRIPTION
User can specify the type that holds the sum of the Moving Average to prevent wrapping and overflows.