### PR TITLE
MircoRosTransport: Add C++ methods

### DIFF
--- a/lib/APPTurtle/src/CustomRosTransport.cpp
+++ b/lib/APPTurtle/src/CustomRosTransport.cpp
@@ -63,7 +63,7 @@
  *
  * @return The this pointer to transport owning CustomRosTransport class.
  */
-static CustomRosTransport* toThis(const uxrCustomTransport* transport);
+static inline CustomRosTransport* toThis(const uxrCustomTransport* transport);
 
 /******************************************************************************
  * Local Variables
@@ -96,26 +96,6 @@ size_t CustomRosTransport::read(uxrCustomTransport* transport, uint8_t* buffer, 
 {
     CustomRosTransport * tp = toThis(transport);
     return (nullptr != tp) ? tp->read(buffer, size, timeout, errorCode) : 0U;
-}
-
-/******************************************************************************
- * Local Functions
- *****************************************************************************/
-
-static CustomRosTransport* toThis(const uxrCustomTransport* transport)
-{
-    CustomRosTransport* transportClass = nullptr;
-    
-    if (nullptr == transport)
-    {
-        LOG_FATAL("Invalid uxrCustomTransport pointer.");
-    }
-    else
-    {
-        transportClass = reinterpret_cast<CustomRosTransport*>(transport->args);
-    }
-
-    return transportClass;
 }
 
 /******************************************************************************
@@ -252,3 +232,23 @@ size_t CustomRosTransport::read(uint8_t* buffer, size_t size, int timeout, uint8
 /******************************************************************************
  * External Functions
  *****************************************************************************/
+
+/******************************************************************************
+ * Local Functions
+ *****************************************************************************/
+
+static inline CustomRosTransport* toThis(const uxrCustomTransport* transport)
+{
+    CustomRosTransport* transportClass = nullptr;
+    
+    if (nullptr == transport)
+    {
+        LOG_FATAL("Invalid uxrCustomTransport pointer.");
+    }
+    else
+    {
+        transportClass = reinterpret_cast<CustomRosTransport*>(transport->args);
+    }
+
+    return transportClass;
+}

--- a/lib/APPTurtle/src/CustomRosTransport.h
+++ b/lib/APPTurtle/src/CustomRosTransport.h
@@ -120,7 +120,7 @@ public:
     }
 
     /**
-     * Open and initialize the custom transport.
+     * Open and initialize the custom transport (C-Entry Point).
      * https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/
      *
      * @param[in] transport The arguments passed through uxr_init_custom_transport.
@@ -130,7 +130,7 @@ public:
     static bool open(uxrCustomTransport* transport);
 
     /**
-     * Close the custom transport.
+     * Close the custom transport (C-Entry Point).
      * https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/
      *
      * @param[in] transport The arguments passed through uxr_init_custom_transport.
@@ -140,7 +140,7 @@ public:
     static bool close(uxrCustomTransport* transport);
 
     /**
-     * Write data to the custom transport.
+     * Write data to the custom transport (C-Entry Point).
      * https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/
      *
      * @param[in]  transport The arguments passed through uxr_init_custom_transport.
@@ -153,7 +153,7 @@ public:
     static size_t write(uxrCustomTransport* transport, const uint8_t* buffer, size_t size, uint8_t* errorCode);
 
     /**
-     * Read data from the custom transport.
+     * Read data from the custom transport (C-Entry Point).
      * https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/
      *
      * @param[in]  transport The arguments passed through uxr_init_custom_transport.
@@ -167,6 +167,43 @@ public:
     static size_t read(uxrCustomTransport* transport, uint8_t* buffer, size_t size, int timeout, uint8_t* errorCode);
 
 private:
+    /**
+     * Open and initialize the custom transport.
+     *
+     * @return A boolean indicating if the opening was successful.
+     */
+    bool open(void);
+
+    /**
+     * Close the custom transport.
+     *
+     * @return A boolean indicating if the closing was successful.
+     */
+    bool close(void);
+
+    /**
+     * Write data to the custom transport.
+     *
+     * @param[in]  buffer The buffer to write.
+     * @param[in]  size The size of the buffer.
+     * @param[out] errorCode The error code.
+     *
+     * @return The number of bytes written.
+     */
+    size_t write(const uint8_t* buffer, size_t size, uint8_t* errorCode);
+
+    /**
+     * Read data from the custom transport.
+     *
+     * @param[out] buffer The buffer to read into.
+     * @param[in]  size The size of the buffer.
+     * @param[in]  timeout The timeout in milliseconds.
+     * @param[out] errorCode The error code.
+     *
+     * @return The number of bytes read.
+     */
+    size_t read(uint8_t* buffer, size_t size, int timeout, uint8_t* errorCode);
+
     /**
      * Default Micro-ROS agent port.
      */

--- a/lib/APPTurtle/src/MicroRosClient.cpp
+++ b/lib/APPTurtle/src/MicroRosClient.cpp
@@ -283,8 +283,8 @@ void MicroRosClient::waitingForAgentState()
          */
         if ((false == m_timer.isTimerRunning()) || (true == m_timer.isTimeout()))
         {
-            LOG_INFO("Ping Micro-ROS agent %s:%u ...", m_customRosTransport.getIPAddressAsStr().c_str(),
-                     m_customRosTransport.getPort());
+            String ipAddStr = m_customRosTransport.getIPAddressAsStr();
+            LOG_INFO("Ping Micro-ROS agent %s:%u ...", ipAddStr.c_str(), m_customRosTransport.getPort());
 
             if (RMW_RET_OK == rmw_uros_ping_agent(MICRO_ROS_AGENT_PING_TIMEOUT, MICRO_ROS_AGENT_PING_ATTEMPTS))
             {
@@ -305,8 +305,9 @@ void MicroRosClient::waitingForAgentState()
 
 void MicroRosClient::connectingState()
 {
-    LOG_INFO("Connecting to Micro-ROS agent %s:%u ...", m_customRosTransport.getIPAddressAsStr().c_str(),
-             m_customRosTransport.getPort());
+    String ipAddStr = m_customRosTransport.getIPAddressAsStr();
+
+    LOG_INFO("Connecting to Micro-ROS agent %s:%u ...", ipAddStr.c_str(), m_customRosTransport.getPort());
 
     if (false == createEntities())
     {
@@ -314,8 +315,7 @@ void MicroRosClient::connectingState()
     }
     else
     {
-        LOG_INFO("Connected with Micro-ROS agent %s:%u.", m_customRosTransport.getIPAddressAsStr().c_str(),
-                 m_customRosTransport.getPort());
+        LOG_INFO("Connected with Micro-ROS agent %s:%u.", ipAddStr.c_str(), m_customRosTransport.getPort());
 
         subscribe();
 


### PR DESCRIPTION
Add c++ transport handler and  make the C-functions entry points only wrappers for the new c++ ones.

This removes the need for a "handcrafted" this pointer inside the C-methods for accessing Class elements.