### PR TITLE
Custom options have to start with custom_ or board_ to

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -102,11 +102,11 @@ extra_scripts =
     post:./scripts/copy_webots_shared_libs.py
 
 ; Custom options (https://docs.platformio.org/en/latest/scripting/examples/platformio_ini_custom_options.html)
-webots_ip_address = 127.0.0.1 ; IP address of the Webots simulation, which is used for TCP communication
-webots_protocol = ipc ; [ipc|tcp] - ipc is faster but only works on the same machine, tcp works also over network
-webots_robot_name = ZumoComSystem
-webots_robot_serial_rx_channel = 4
-webots_robot_serial_tx_channel = 3
+custom_webots_ip_address = 127.0.0.1 ; IP address of the Webots simulation, which is used for TCP communication
+custom_webots_protocol = ipc ; [ipc|tcp] - ipc is faster but only works on the same machine, tcp works also over network
+custom_webots_robot_name = ZumoComSystem
+custom_webots_robot_serial_rx_channel = 4
+custom_webots_robot_serial_tx_channel = 3
 
 ; *****************************************************************************
 ; PC target environment for tests

--- a/platformio_override.ini
+++ b/platformio_override.ini
@@ -19,8 +19,8 @@
 ; Webots directory, e.g. WEBOTS_HOME=C:\Users\<user>\AppData\Local\Programs\Webots
 ; *****************************************************************************
 [target:Sim]
-webots_ip_address = 127.0.0.1 ; IP address of the Webots simulation, which is used for TCP communication
-webots_protocol = ipc ; [ipc|tcp] - ipc is faster but only works on the same machine, tcp works also over network
-webots_robot_name = ZumoComSystem
-webots_robot_serial_rx_channel = 4
-webots_robot_serial_tx_channel = 3
+custom_webots_ip_address = 127.0.0.1 ; IP address of the Webots simulation, which is used for TCP communication
+custom_webots_protocol = ipc ; [ipc|tcp] - ipc is faster but only works on the same machine, tcp works also over network
+custom_webots_robot_name = ZumoComSystem
+custom_webots_robot_serial_rx_channel = 4
+custom_webots_robot_serial_tx_channel = 3

--- a/scripts/webots_launcher.py
+++ b/scripts/webots_launcher.py
@@ -40,13 +40,13 @@ OS_PLATFORM_TYPE_LINUX = "Linux"
 OS_PLATFORM_TYPE_MACOS = "Darwin"
 OS_PLATFORM_TYPE = platform.system()
 
-WEBOTS_IP_ADDRESS = env.GetProjectOption("webots_ip_address")  # pylint: disable=undefined-variable
-WEBOTS_PROTOCOL = env.GetProjectOption("webots_protocol")  # pylint: disable=undefined-variable
+WEBOTS_IP_ADDRESS = env.GetProjectOption("custom_webots_ip_address")  # pylint: disable=undefined-variable
+WEBOTS_PROTOCOL = env.GetProjectOption("custom_webots_protocol")  # pylint: disable=undefined-variable
 
-ROBOT_NAME = env.GetProjectOption("webots_robot_name")  # pylint: disable=undefined-variable
+ROBOT_NAME = env.GetProjectOption("custom_webots_robot_name")  # pylint: disable=undefined-variable
 
-ROBOT_SERIAL_RX_CHANNEL = env.GetProjectOption("webots_robot_serial_rx_channel")  # pylint: disable=undefined-variable
-ROBOT_SERIAL_TX_CHANNEL = env.GetProjectOption("webots_robot_serial_tx_channel")  # pylint: disable=undefined-variable
+ROBOT_SERIAL_RX_CHANNEL = env.GetProjectOption("custom_webots_robot_serial_rx_channel")  # pylint: disable=undefined-variable
+ROBOT_SERIAL_TX_CHANNEL = env.GetProjectOption("custom_webots_robot_serial_tx_channel")  # pylint: disable=undefined-variable
 
 PROGRAM_PATH = "$BUILD_DIR/"
 PROGRAM_OPTIONS = '--cfgFilePath "../../../data/config/config.json" ' \


### PR DESCRIPTION
Custom options have to start with custom_ or board_ to not generate a warning that the unknown configuration option will be ignored by PlatformIO.

#222 