### PR TITLE
feat(HAL): add ZumoComSystem V3 hardware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Together with [Radon Ulzer](https://github.com/BlueAndi/RadonUlzer) it can be ru
 
 ### Installation for target
 
-1. Make sure that the hardware version of your [ZumoComSystem](https://github.com/NewTec-GmbH/ZumoComSystem) is supported. Currently, only v1.1 and v1.2 are supported.
+1. Make sure that the hardware version of your [ZumoComSystem](https://github.com/NewTec-GmbH/ZumoComSystem) is supported. Currently, v1 (v1.1 and v1.2), v2 and [v3](https://github.com/NewTec-GmbH/ZumoComSystemHW) are supported. Select the hardware version in the ```[target:esp32]``` section of ```platformio.ini```.
 2. Install the [drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads) for the CP2102 USB-UART converter if required. The "CP210x Universal Windows Driver" is recommended, as it enables the automatic bootloader mode.
 
 ### Build and flash procedure

--- a/config/hardwareversion.ini
+++ b/config/hardwareversion.ini
@@ -2,6 +2,8 @@
 ; Target Hardware Version configurations
 ;   * V1: ESP32 with 4MB flash. External USB Host controller.
 ;   * V2: ESP32-S3 with 16MB flash. Integrated USB Host controller. Buttons and LEDs A, B and C.
+;   * V3: ESP32-S3 with 16MB flash. UART connection to the Zumo2040 robot. Buttons and LEDs
+;         A, B and C. USB-C port for flashing.
 ; *************************************************************************************************
 
 ; *****************************************************************************
@@ -30,6 +32,7 @@ lib_ignore =
     ArduinoNative
     HALSim
     HALTargetV2
+    HALTargetV3
     HALTest
     MainNative
     MainTestNative
@@ -65,12 +68,49 @@ lib_ignore =
     ArduinoNative
     HALSim
     HALTargetV1
+    HALTargetV3
     HALTest
     MainNative
     MainTestNative
     UDPNative
     WiFiNative
     WifiClientNative
-extra_scripts = 
+extra_scripts =
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+
+; *****************************************************************************
+; Target environment for ZumoComSystemV3.
+; *****************************************************************************
+[version:V3]
+extends = mode:selected_esp32
+platform = espressif32 @ ~6.11.0
+board = esp32-s3-devkitc-1
+board_build.filesystem = littlefs
+framework = arduino
+build_flags =
+    ${mode:selected_esp32.build_flags}
+    -Wl,-Map,firmware.map
+    -D CONFIG_FILE_PATH="\"/config/config.json\""
+lib_deps =
+    HALInterfaces
+    HALTargetV3
+    HALTargetCommon
+    knolleary/PubSubClient @ ~2.8
+    SPI
+    FS
+    LittleFS
+lib_ignore =
+    ArduinoNative
+    HALSim
+    HALTargetV1
+    HALTargetV2
+    HALTest
+    MainNative
+    MainTestNative
+    UDPNative
+    WiFiNative
+    WifiClientNative
+extra_scripts =
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder

--- a/doc/doxygen/ConvoyFollowerTargetDoxyfile
+++ b/doc/doxygen/ConvoyFollowerTargetDoxyfile
@@ -996,6 +996,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/HALInterfaces \
                          ../../lib/APPConvoyFollower \
                          ../../lib/Service \

--- a/doc/doxygen/ConvoyLeaderTargetDoxyfile
+++ b/doc/doxygen/ConvoyLeaderTargetDoxyfile
@@ -998,6 +998,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/PlatoonService \
                          ../../lib/Service \
                          ../../lib/Utilities

--- a/doc/doxygen/LineFollowerTargetDoxyfile
+++ b/doc/doxygen/LineFollowerTargetDoxyfile
@@ -996,6 +996,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/HALInterfaces \
                          ../../lib/APPLineFollower \
                          ../../lib/Service \

--- a/doc/doxygen/RemoteControlTargetDoxyfile
+++ b/doc/doxygen/RemoteControlTargetDoxyfile
@@ -996,6 +996,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/HALInterfaces \
                          ../../lib/APPRemoteControl \
                          ../../lib/Service \

--- a/doc/doxygen/SensorFusionTargetDoxyfile
+++ b/doc/doxygen/SensorFusionTargetDoxyfile
@@ -996,6 +996,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/HALInterfaces \
                          ../../lib/APPSensorFusion \
                          ../../lib/Service \

--- a/doc/doxygen/TurtleTargetDoxyfile
+++ b/doc/doxygen/TurtleTargetDoxyfile
@@ -998,6 +998,7 @@ INPUT                  = mainpage.dox \
                          ../../lib/HALTargetCommon \
                          ../../lib/HALTargetV1 \
                          ../../lib/HALTargetV2 \
+                         ../../lib/HALTargetV3 \
                          ../../lib/Service \
                          ../../lib/Utilities
 

--- a/doc/doxygen/mainpage.dox
+++ b/doc/doxygen/mainpage.dox
@@ -30,6 +30,11 @@ Abstracts the physical hardware of the ZumoComSystemV2.
 @{
 @}
 
+@defgroup HALTargetV3 Hardware abstraction of the ZumoComSystemV3
+Abstracts the physical hardware of the ZumoComSystemV3.
+@{
+@}
+
 @defgroup HALSim Hardware abstraction in Webots simulation
 Abstracts the the hardware in the Webots simulation.
 @{

--- a/lib/HALTargetV3/library.json
+++ b/lib/HALTargetV3/library.json
@@ -1,0 +1,17 @@
+{
+    "name": "HALTargetV3",
+    "version": "0.1.0",
+    "description": "Hardware abstraction layer for the ZumoComSystemV3.",
+    "authors": [{
+        "name": "Andreas Merkle",
+        "email": "web@blue-andi.de",
+        "url": "https://github.com/BlueAndi",
+        "maintainer": true
+    }],
+    "license": "MIT",
+    "dependencies": [{
+        "name": "Os"
+    }],
+    "frameworks": "arduino",
+    "platforms": "*"
+}

--- a/lib/HALTargetV3/src/Pin.h
+++ b/lib/HALTargetV3/src/Pin.h
@@ -1,0 +1,110 @@
+/* MIT License
+ *
+ * Copyright (c) 2023 - 2026 Andreas Merkle <web@blue-andi.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*******************************************************************************
+    DESCRIPTION
+*******************************************************************************/
+/**
+ * @file
+ * @brief  Pin definition for the target board.
+ * @author Gabryel Reyes <gabryelrdiaz@gmail.com>
+ *
+ * @addtogroup HALTargetV3
+ *
+ * @{
+ */
+#ifndef PIN_H
+#define PIN_H
+
+/******************************************************************************
+ * Compile Switches
+ *****************************************************************************/
+
+/******************************************************************************
+ * Includes
+ *****************************************************************************/
+
+#include <stdint.h>
+#include <Io.hpp>
+
+/******************************************************************************
+ * Macros
+ *****************************************************************************/
+
+/******************************************************************************
+ * Types and Classes
+ *****************************************************************************/
+
+/** Pin number of all used pins. */
+namespace Pin
+{
+    /** Pin for push button for system reset/AP mode start (ACTIVE LOW) */
+    constexpr uint8_t PIN_WIFI_AND_RESET_KEY = 48U;
+
+    /** Pin for resetting the attached Zumo robot (ACTIVE LOW) */
+    constexpr uint8_t PIN_DEVICE_RESET = 4U;
+
+    /** Pin for info LED RGB channel RED (ACTIVE LOW) */
+    constexpr uint8_t INFO_LED_R = 38U;
+
+    /** Pin for info LED RGB channel GREEN (ACTIVE LOW) */
+    constexpr uint8_t INFO_LED_G = 1U;
+
+    /** Pin for info LED RGB channel BLUE (ACTIVE LOW) */
+    constexpr uint8_t INFO_LED_B = 2U;
+
+    /** Pin for analog measurement of battery voltage */
+    constexpr uint8_t PIN_BATT_MEASUREMENT = 18U;
+
+    /** Pin for push button A */
+    constexpr uint8_t PIN_BUTTON_A = 6U;
+
+    /** Pin for push button B */
+    constexpr uint8_t PIN_BUTTON_B = 7U;
+
+    /** Pin for push button C */
+    constexpr uint8_t PIN_BUTTON_C = 16U;
+
+    /** Pin for LED A */
+    constexpr uint8_t PIN_LED_A = 5U;
+
+    /** Pin for LED B */
+    constexpr uint8_t PIN_LED_B = 15U;
+
+    /** Pin for LED C */
+    constexpr uint8_t PIN_LED_C = 17U;
+
+    /** Pin for UART transmission (ESP_UART1_TX) towards the attached Zumo robot */
+    constexpr uint8_t PIN_ROBOT_UART_TX = 21U;
+
+    /** Pin for UART reception (ESP_UART1_RX) from the attached Zumo robot */
+    constexpr uint8_t PIN_ROBOT_UART_RX = 47U;
+
+}; /* namespace Pin */
+
+/******************************************************************************
+ * Functions
+ *****************************************************************************/
+
+#endif /* PIN_H */
+/** @} */

--- a/lib/HALTargetV3/src/USBHostDriver.cpp
+++ b/lib/HALTargetV3/src/USBHostDriver.cpp
@@ -72,12 +72,21 @@ USBHost::~USBHost()
 
 bool USBHost::init()
 {
-    (void)m_robotSerial.setRxBufferSize(UART_RX_BUFFER_SIZE);
-    m_robotSerial.begin(BAUD_RATE, SERIAL_8N1, Pin::PIN_ROBOT_UART_RX, Pin::PIN_ROBOT_UART_TX);
+    bool isSuccess = false;
 
-    LOG_DEBUG("Robot UART driver has been successfully initialized.");
+    if (0U == m_robotSerial.setRxBufferSize(UART_RX_BUFFER_SIZE))
+    {
+        LOG_ERROR("Could not set the UART RX buffer size.");
+    }
+    else
+    {
+        m_robotSerial.begin(BAUD_RATE, SERIAL_8N1, Pin::PIN_ROBOT_UART_RX, Pin::PIN_ROBOT_UART_TX);
 
-    return true;
+        LOG_DEBUG("Robot UART driver has been successfully initialized.");
+        isSuccess = true;
+    }
+
+    return isSuccess;
 }
 
 void USBHost::process()

--- a/lib/HALTargetV3/src/USBHostDriver.cpp
+++ b/lib/HALTargetV3/src/USBHostDriver.cpp
@@ -1,0 +1,172 @@
+/* MIT License
+ *
+ * Copyright (c) 2023 - 2026 Andreas Merkle <web@blue-andi.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*******************************************************************************
+    DESCRIPTION
+*******************************************************************************/
+/**
+ * @file
+ * @brief  Abstraction and Stream implementation of the host connection to the
+ *         robot via UART.
+ * @author Gabryel Reyes <gabryelrdiaz@gmail.com>
+ */
+
+/******************************************************************************
+ * Includes
+ *****************************************************************************/
+#include "USBHostDriver.h"
+#include "Pin.h"
+#include <Logging.h>
+
+/******************************************************************************
+ * Compiler Switches
+ *****************************************************************************/
+
+/******************************************************************************
+ * Macros
+ *****************************************************************************/
+
+/******************************************************************************
+ * Types and classes
+ *****************************************************************************/
+
+/******************************************************************************
+ * Prototypes
+ *****************************************************************************/
+
+/******************************************************************************
+ * Local Variables
+ *****************************************************************************/
+
+/******************************************************************************
+ * Public Methods
+ *****************************************************************************/
+
+USBHost::USBHost() : Stream(), m_robotSerial(Serial1), m_isBootloaderModeActive(false)
+{
+}
+
+USBHost::~USBHost()
+{
+}
+
+bool USBHost::init()
+{
+    (void)m_robotSerial.setRxBufferSize(UART_RX_BUFFER_SIZE);
+    m_robotSerial.begin(BAUD_RATE, SERIAL_8N1, Pin::PIN_ROBOT_UART_RX, Pin::PIN_ROBOT_UART_TX);
+
+    LOG_DEBUG("Robot UART driver has been successfully initialized.");
+
+    return true;
+}
+
+void USBHost::process()
+{
+    /* Nothing to do. Reception is handled by the UART driver. */
+}
+
+size_t USBHost::write(uint8_t value)
+{
+    return m_robotSerial.write(value);
+}
+
+size_t USBHost::write(const uint8_t* buffer, size_t length)
+{
+    return m_robotSerial.write(buffer, length);
+}
+
+int USBHost::available()
+{
+    return m_robotSerial.available();
+}
+
+int USBHost::read()
+{
+    return m_robotSerial.read();
+}
+
+int USBHost::peek()
+{
+    return m_robotSerial.peek();
+}
+
+size_t USBHost::readBytes(uint8_t* buffer, size_t length)
+{
+    size_t count = 0;
+
+    while ((count < length) && (0 < m_robotSerial.available()))
+    {
+        int byte = m_robotSerial.read();
+
+        if (0 > byte)
+        {
+            break;
+        }
+
+        buffer[count] = static_cast<uint8_t>(byte);
+        ++count;
+    }
+
+    return count;
+}
+
+void USBHost::requestBootloaderMode()
+{
+    /* Reset flags and flush the receive buffer. */
+    reset();
+
+    /* Request bootloader mode. */
+    m_isBootloaderModeActive = true;
+}
+
+void USBHost::reset()
+{
+    m_isBootloaderModeActive = false;
+
+    /* Flush the receive buffer. */
+    while (0 < m_robotSerial.available())
+    {
+        (void)m_robotSerial.read();
+    }
+}
+
+bool USBHost::isBootloaderModeActive() const
+{
+    return m_isBootloaderModeActive;
+}
+
+/******************************************************************************
+ * Protected Methods
+ *****************************************************************************/
+
+/******************************************************************************
+ * Private Methods
+ *****************************************************************************/
+
+/******************************************************************************
+ * External Functions
+ *****************************************************************************/
+
+/******************************************************************************
+ * Local Functions
+ *****************************************************************************/

--- a/lib/HALTargetV3/src/USBHostDriver.h
+++ b/lib/HALTargetV3/src/USBHostDriver.h
@@ -1,0 +1,183 @@
+/* MIT License
+ *
+ * Copyright (c) 2023 - 2026 Andreas Merkle <web@blue-andi.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*******************************************************************************
+    DESCRIPTION
+*******************************************************************************/
+/**
+ * @file
+ * @brief  Abstraction and Stream implementation of the host connection to the
+ *         robot. On the ZumoComSystemV3 the Zumo robot is attached via UART
+ *         instead of USB, therefore this driver realizes the host interface
+ *         on top of a hardware serial port.
+ * @author Gabryel Reyes <gabryelrdiaz@gmail.com>
+ *
+ * @addtogroup HALTargetV3
+ *
+ * @{
+ */
+
+#ifndef USBHOSTDRIVER_H
+#define USBHOSTDRIVER_H
+
+/******************************************************************************
+ * Compile Switches
+ *****************************************************************************/
+
+/******************************************************************************
+ * Includes
+ *****************************************************************************/
+#include <Stream.h>
+#include <HardwareSerial.h>
+
+/******************************************************************************
+ * Macros
+ *****************************************************************************/
+
+/******************************************************************************
+ * Types and Classes
+ *****************************************************************************/
+
+/** Class for configuring and managing the host connection to the robot. */
+class USBHost : public Stream
+{
+public:
+    /**
+     * Default constructor
+     */
+    USBHost();
+
+    /**
+     * Default destructor
+     */
+    ~USBHost();
+
+    /**
+     * Initializes the host connection to the robot.
+     *
+     * @returns true if initialization is successful. Otherwise, false.
+     */
+    bool init();
+
+    /**
+     * Process the device connection.
+     */
+    void process();
+
+    /**
+     * Print single byte.
+     * @param[in] value Byte to send.
+     * @returns Number of bytes written
+     */
+    size_t write(uint8_t value) final;
+
+    /**
+     * Write bytes.
+     * @param[in] buffer Byte Array to send.
+     * @param[in] length Length of Buffer.
+     * @returns Number of bytes written
+     */
+    size_t write(const uint8_t* buffer, size_t length) final;
+
+    /**
+     * Check if there are available bytes in the Stream.
+     * @returns Number of available bytes.
+     */
+    int available() final;
+
+    /**
+     * Read a byte from the Stream.
+     * @returns The first byte of incoming data available (or -1 if no data is available).
+     */
+    int read() final;
+
+    /**
+     * Peek a byte from the Stream.
+     * @returns The first byte of incoming data available (or -1 if no data is available).
+     */
+    int peek() final;
+
+    /**
+     * Read bytes into a buffer.
+     * @param[in] buffer Array to write bytes to.
+     * @param[in] length number of bytes to be read.
+     * @returns Number of bytes read from Stream.
+     */
+    size_t readBytes(uint8_t* buffer, size_t length) final;
+
+    /**
+     * Request to enter the bootloader mode.
+     */
+    void requestBootloaderMode();
+
+    /**
+     * Reset the flags and flush the receive buffer.
+     */
+    void reset();
+
+    /**
+     * Check if the bootloader mode is active.
+     *
+     * @return If the bootloader mode is active, returns true. Otherwise, false.
+     */
+    bool isBootloaderModeActive() const;
+
+private:
+    /** Baud rate of the UART connection to the robot. */
+    static const uint32_t BAUD_RATE = 115200U;
+
+    /** Size of the UART RX buffer in bytes. */
+    static const uint16_t UART_RX_BUFFER_SIZE = 1024U;
+
+    /** UART connection to the robot. */
+    HardwareSerial& m_robotSerial;
+
+    /** Bootloader Mode Flag. */
+    bool m_isBootloaderModeActive;
+
+private:
+    /**
+     * Copy construction of an instance.
+     * Not allowed.
+     *
+     * @param[in] usbhost Source instance.
+     */
+    USBHost(const USBHost& usbhost);
+
+    /**
+     * Assignment of an instance.
+     * Not allowed.
+     *
+     * @param[in] usbhost Source instance.
+     *
+     * @returns Reference to USBHost instance.
+     */
+    USBHost& operator=(const USBHost& usbhost);
+};
+
+/******************************************************************************
+ * Functions
+ *****************************************************************************/
+
+#endif /* USBHOSTDRIVER_H */
+/** @} */

--- a/lib/HALTargetV3/src/USBHostDriver.h
+++ b/lib/HALTargetV3/src/USBHostDriver.h
@@ -80,63 +80,72 @@ public:
     bool init();
 
     /**
-     * Process the device connection.
+     * Processes the device connection.
      */
     void process();
 
     /**
-     * Print single byte.
+     * Writes a single byte.
+     *
      * @param[in] value Byte to send.
+     *
      * @returns Number of bytes written
      */
     size_t write(uint8_t value) final;
 
     /**
-     * Write bytes.
+     * Writes bytes.
+     *
      * @param[in] buffer Byte Array to send.
      * @param[in] length Length of Buffer.
+     *
      * @returns Number of bytes written
      */
     size_t write(const uint8_t* buffer, size_t length) final;
 
     /**
-     * Check if there are available bytes in the Stream.
+     * Checks if there are available bytes in the Stream.
+     *
      * @returns Number of available bytes.
      */
     int available() final;
 
     /**
-     * Read a byte from the Stream.
+     * Reads a byte from the Stream.
+     *
      * @returns The first byte of incoming data available (or -1 if no data is available).
      */
     int read() final;
 
     /**
-     * Peek a byte from the Stream.
+     * Peeks a byte from the Stream.
+     *
      * @returns The first byte of incoming data available (or -1 if no data is available).
      */
     int peek() final;
 
     /**
-     * Read bytes into a buffer.
+     * Reads bytes into a buffer.
+     *
      * @param[in] buffer Array to write bytes to.
      * @param[in] length number of bytes to be read.
+     *
      * @returns Number of bytes read from Stream.
      */
     size_t readBytes(uint8_t* buffer, size_t length) final;
 
     /**
-     * Request to enter the bootloader mode.
+     * Requests to enter the bootloader mode.
      */
     void requestBootloaderMode();
 
     /**
-     * Reset the flags and flush the receive buffer.
+     * Resets the flags and flushes the receive buffer.
      */
     void reset();
 
     /**
-     * Check if the bootloader mode is active.
+     * Checks if the bootloader mode is active.
      *
      * @return If the bootloader mode is active, returns true. Otherwise, false.
      */

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,6 +92,7 @@ lib_ignore =
     HALTargetCommon
     HALTargetV1
     HALTargetV2
+    HALTargetV3
     HALTest
     MainTestNative
 extra_scripts =
@@ -130,6 +131,7 @@ lib_ignore =
     HALTargetCommon
     HALTargetV1
     HALTargetV2
+    HALTargetV3
     MainNative
 extra_scripts =
     pre:./scripts/add_os_specific_build_flags.py


### PR DESCRIPTION
Add support for the ZumoComSystem hardware V3 (NewTec-GmbH/ZumoComSystemHW v3.1), which is a shield for the Pololu Zumo2040 robot:

- New HALTargetV3 library with the V3 pin assignment derived from the v3.1 KiCad schematics.
- The Zumo robot is attached via UART on V3 instead of USB. The host driver implements the same Stream interface on top of UART1 (TX: GPIO21, RX: GPIO47, 115200 baud).
- New [version:V3] build environment in config/hardwareversion.ini.
- Doxygen and README updated.

Closes #225